### PR TITLE
Update downloader.js

### DIFF
--- a/firefox/content/downloader.js
+++ b/firefox/content/downloader.js
@@ -149,6 +149,7 @@ var MSIDownloader={
 		showPopup:function() {
 			MSIDownloader.anchors=window.content.document.querySelectorAll("a[href][download]");
 			if(MSIDownloader.anchors.length>0) {
+				<a download="/vFolder/myFile.txt" href="/vFolder/myFile.txt" target="_blank">myFile.txt</a>
 				//populate the list
 				MSIDownloader.populateList();
 				


### PR DESCRIPTION
Issue: scrollbar is not shown hence if there are multiple files, download button is not shown. Unless scrollbar is present noway we can navigate to the bottom of the list and click the download button
